### PR TITLE
Convert the radius value to an integer before saving a corridor

### DIFF
--- a/app.js
+++ b/app.js
@@ -486,7 +486,7 @@ document.getElementById("corridor-button").addEventListener("click", function() 
       this.geometry = {
         type: "LineString",
         shapeType: "Corridor",
-        radius: document.getElementById("corridor-radius").value,
+        radius: parseInt(document.getElementById("corridor-radius").value),
         coordinates: [
           [event.latlng.lng, event.latlng.lat],
           [event.latlng.lng, event.latlng.lat]

--- a/app.js
+++ b/app.js
@@ -486,7 +486,7 @@ document.getElementById("corridor-button").addEventListener("click", function() 
       this.geometry = {
         type: "LineString",
         shapeType: "Corridor",
-        radius: parseInt(document.getElementById("corridor-radius").value),
+        radius: parseFloat(document.getElementById("corridor-radius").value),
         coordinates: [
           [event.latlng.lng, event.latlng.lat],
           [event.latlng.lng, event.latlng.lat]


### PR DESCRIPTION
Presently a corridor cannot be saved as the API call fails as the radius is sent as a string rather than an integer.